### PR TITLE
[FSDP] Enable multiple parameter groups within a `FlatParameter`

### DIFF
--- a/test/distributed/fsdp/test_fsdp_core.py
+++ b/test/distributed/fsdp/test_fsdp_core.py
@@ -8,9 +8,12 @@ from unittest import mock
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from torch.testing._internal.common_distributed import (
-    skip_if_lt_x_gpu,
+from torch.distributed.fsdp import CPUOffload, MixedPrecision
+from torch.distributed.fsdp.fully_sharded_data_parallel import (
+    BackwardPrefetch,
+    ShardingStrategy,
 )
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DummyDDP,
     FSDPInitMode,
@@ -19,7 +22,7 @@ from torch.testing._internal.common_fsdp import (
     NestedWrappedModule,
     NestedWrappedModuleWithDelay,
     TransformerWithSharedParams,
-    subtest_name
+    subtest_name,
 )
 from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
@@ -27,10 +30,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
 )
-
-from torch.distributed.fsdp import CPUOffload, MixedPrecision
-from torch.distributed.fsdp.fully_sharded_data_parallel import BackwardPrefetch, ShardingStrategy
-
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -290,6 +290,7 @@ class TestFSDPOptimState(FSDPTest):
         losses = []
         module = model.module if hasattr(model, "module") else model
         for _ in range(num_iters):
+            optim.zero_grad()
             inp = module.get_input(device)
             output = model(*inp)
             loss = module.get_loss(inp, output).to(device)

--- a/test/distributed/fsdp/test_fsdp_summon_full_params.py
+++ b/test/distributed/fsdp/test_fsdp_summon_full_params.py
@@ -7,25 +7,24 @@ from copy import deepcopy
 import torch
 import torch.nn as nn
 from torch import distributed as dist
-from torch.distributed.fsdp import CPUOffload, MixedPrecision
-from torch.distributed.fsdp import FlatParameter
+from torch.distributed.fsdp import CPUOffload
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel
-from torch.distributed.fsdp.wrap import wrap, enable_wrap
+from torch.distributed.fsdp import MixedPrecision
+from torch.distributed.fsdp.flat_param import FlatParamHandle
+from torch.distributed.fsdp.wrap import enable_wrap, wrap
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
+    DeterministicModel,
     FSDPInitMode,
     FSDPTest,
     NestedWrappedModule,
-    DeterministicModel,
 )
 from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
-    run_tests,
     instantiate_parametrized_tests,
     parametrize,
+    run_tests,
 )
-
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)
@@ -146,7 +145,7 @@ class TestSummonFullParams(FSDPTest):
         with model.summon_full_params(model):
             self.assertEqual(raw_model_size, self.get_model_param_count(model))
             parameters = list(model.parameters())
-            all_shards = FlatParameter(parameters, requires_grad=False)
+            all_shards = FlatParamHandle.flatten_params(parameters, requires_grad=False)
             my_slice = torch.chunk(all_shards, self.world_size)[self.rank]
 
             # shards are padded but the full_param tensor is not
@@ -351,7 +350,7 @@ class TestSummonFullParams(FSDPTest):
         )
 
         params_to_compare = list(model_no_fsdp.parameters())
-        with FullyShardedDataParallel.summon_full_params(model_fsdp):
+        with FSDP.summon_full_params(model_fsdp):
             fsdp_params = [p.clone() for p in model_fsdp.parameters()]
 
         self.assertEqual(params_to_compare, fsdp_params)

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -1,0 +1,174 @@
+# Owner(s): ["oncall: distributed"]
+
+import functools
+import sys
+
+import torch
+import torch.nn as nn
+from torch import distributed as dist
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
+from torch.nn.parallel.distributed import DistributedDataParallel as DDP
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+from torch.testing._internal.common_fsdp import FSDPTest
+from torch.testing._internal.common_utils import (
+    TEST_WITH_DEV_DBG_ASAN,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+)
+
+if not dist.is_available():
+    print("Distributed not available, skipping tests", file=sys.stderr)
+    sys.exit(0)
+
+if TEST_WITH_DEV_DBG_ASAN:
+    print(
+        "Skip dev-asan as torch + multiprocessing spawn have known issues",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+
+class Model(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.p1 = nn.Parameter(torch.randn(5, 5))
+        self.p2 = nn.Parameter(torch.randn(5, 4))
+        self.p3 = nn.Parameter(torch.randn(4, 3))
+        self.relu = nn.ReLU()
+
+    def forward(self, x):
+        for p in (self.p1, self.p2, self.p3):
+            x = x @ p
+            x = self.relu(x)
+        return x
+
+
+class TestFSDPUseOrigParams(FSDPTest):
+    def _get_optim(self, model):
+        """Constructs three parameter groups, one for weights, one for biases,
+        and one for everything else, each with different weight decay and
+        learning rates."""
+        param_groups = [
+            {"params": [], "weight_decay": 0.1, "lr": 1e-2},
+            {"params": [], "weight_decay": 0.01, "lr": 1e-3},
+            {"params": []}
+        ]
+        for param_name, param in model.named_parameters():
+            if "weight" in param_name:
+                param_groups[0]["params"].append(param)
+            elif "bias" in param_name:
+                param_groups[1]["params"].append(param)
+            else:
+                param_groups[2]["params"].append(param)
+        return torch.optim.Adam(param_groups, lr=5e-3)
+
+    def _get_ddp_transformer(self, find_unused_params: bool = False):
+        """Returns a transformer with shared parameters wrapped with DDP and
+        a corresponding Adam optimizer."""
+        group = dist.distributed_c10d._get_default_group()
+        model = self._get_nonwrapped_model(group).cuda().eval()  # disable dropout
+        ddp_model = DDP(
+            model,
+            device_ids=[self.rank],
+            find_unused_parameters=find_unused_params,
+        )
+        ddp_optim = self._get_optim(ddp_model)
+        return ddp_model, ddp_optim
+
+    def _get_fsdp_transformer(self, init_optim_before_wrap: bool = False):
+        """Returns a transformer with shared parameters wrapped with FSDP and
+        a corresponding Adam optimizer."""
+        group = dist.distributed_c10d._get_default_group()
+        # Wrap several `Linear`s in the same FSDP instance to guarantee
+        # different hyperparameter settings within that instance's single
+        # `FlatParameter`
+        config = {
+            "auto_wrap_policy": functools.partial(
+                transformer_auto_wrap_policy,
+                transformer_layer_cls={TransformerEncoderLayer, TransformerDecoderLayer},
+            ),
+            "use_orig_params": True,
+        }
+        if init_optim_before_wrap:
+            model = self._get_nonwrapped_model(group).eval()  # disable dropout
+            fsdp_optim = self._get_optim(model)
+            fsdp_model = FSDP(model, group, **config)
+        else:
+            fsdp_model = self._get_wrapped_model(
+                group,
+                cuda_first=True,
+                config=config,
+            ).eval()  # disable dropout
+            fsdp_optim = self._get_optim(fsdp_model)
+        return fsdp_model, fsdp_optim
+
+    def _check_train_parity(
+        self,
+        ddp_model: DDP,
+        ddp_optim: torch.optim.Optimizer,
+        fsdp_model: FSDP,
+        fsdp_optim: torch.optim.Optimizer,
+        num_iters: int = 5,
+    ):
+        """Checks training parity between DDP and FSDP."""
+        device = torch.device("cuda")
+        for _ in range(num_iters):
+            iter_losses = []
+            for model, optim in ((ddp_model, ddp_optim), (fsdp_model, fsdp_optim)):
+                module = model.module
+                optim.zero_grad()
+                inp = module.get_input(device)
+                output = model(*inp)
+                loss = module.get_loss(inp, output).to(device)
+                iter_losses.append(loss)
+                module.run_backward(loss)
+                optim.step()
+            self.assertEqual(iter_losses[0].item(), iter_losses[1].item())
+            iter_losses.clear()
+        with FSDP.summon_full_params(fsdp_model):
+            for p1, p2 in zip(ddp_model.parameters(), fsdp_model.parameters()):
+                torch.testing.assert_close(p1, p2)
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("init_optim_before_wrap", [False, True])
+    def test_diff_hyperparams(self, init_optim_before_wrap: bool):
+        """
+        Tests FSDP parity with DDP when using multiple parameter groups with
+        different hyperparameter settings.
+
+        Args:
+            init_optim_before_wrap (bool): If ``True``, initializes the
+                FSDP optimizer before wrapping the model with FSDP; otherwise,
+                initializes the FSDP optimizer after wrapping the model with
+                FSDP. We permit both forms of initialization to give users
+                flexibility.
+        """
+        ddp_model, ddp_optim = self._get_ddp_transformer()
+        fsdp_model, fsdp_optim = self._get_fsdp_transformer(init_optim_before_wrap)
+        self._check_train_parity(ddp_model, ddp_optim, fsdp_model, fsdp_optim)
+
+    @skip_if_lt_x_gpu(2)
+    def test_diff_trainability(self):
+        """
+        Tests FSDP parity with DDP when using multiple parameter groups and
+        freezing the parameters in one parameter group.
+        """
+        ddp_model, ddp_optim = self._get_ddp_transformer(True)
+        fsdp_model, fsdp_optim = self._get_fsdp_transformer()
+        # Freeze all biases (which are all in the same parameter group)
+        for param_name, param in ddp_model.named_parameters():
+            if "bias" in param_name:
+                param.requires_grad_(False)
+        for param_name, param in fsdp_model.named_parameters():
+            if "bias" in param_name:
+                param.requires_grad_(False)
+        self._check_train_parity(ddp_model, ddp_optim, fsdp_model, fsdp_optim)
+
+
+instantiate_parametrized_tests(TestFSDPUseOrigParams)
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -1,26 +1,23 @@
 # Owner(s): ["oncall: distributed"]
 
-from collections import OrderedDict
 import random
 import sys
 import unittest
+from collections import OrderedDict
 
 import torch
 import torch.nn as nn
 from torch import distributed as dist
-from torch.distributed.fsdp._utils import (
-    _apply_to_tensors,
-)
+from torch.distributed.fsdp._utils import _apply_to_tensors
 from torch.distributed.utils import _replace_by_prefix
 from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
+    TestCase,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
     subtest,
-    TestCase,
 )
-
 
 if not dist.is_available():
     print("Distributed not available, skipping tests", file=sys.stderr)

--- a/torch/distributed/fsdp/__init__.py
+++ b/torch/distributed/fsdp/__init__.py
@@ -1,12 +1,13 @@
-from .flatten_params_wrapper import FlatParameter
-from .fully_sharded_data_parallel import FullyShardedDataParallel
+from .flat_param import FlatParameter
 from .fully_sharded_data_parallel import (
-    CPUOffload,
     BackwardPrefetch,
-    ShardingStrategy,
-    MixedPrecision,
+    CPUOffload,
     FullStateDictConfig,
+    FullyShardedDataParallel,
     LocalStateDictConfig,
+    MixedPrecision,
+    OptimStateKeyType,
+    ShardingStrategy,
+    StateDictType,
 )
-from .fully_sharded_data_parallel import StateDictType, OptimStateKeyType
 from .wrap import ParamExecOrderWrapPolicy

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -160,9 +160,7 @@ def _communicate_optim_state(
                 tensor_buffer = value.new_zeros(*buffer_size)
             dist._all_gather_base(tensor_buffer, value, group=group)
             if to_save:
-                assert hasattr(flat_param, "_orig_size"), \
-                    "Sharded flattened parameter should have `_orig_size` set"
-                unpadded_numel = flat_param._orig_size.numel()  # type: ignore[attr-defined]
+                unpadded_numel = flat_param._unsharded_size.numel()  # type: ignore[attr-defined]
                 tensor_state[state_name] = tensor_buffer[:unpadded_numel].cpu()
         # Zero-dimension tensor state and non-tensor state: take this rank's
         # value directly
@@ -467,7 +465,7 @@ def _flatten_tensor_optim_state(
         in zip(pos_dim_tensors, unflat_param_shapes)
     ]
     flat_tensor = torch.cat(tensors)
-    flat_param_shape = flat_param._orig_size  # type: ignore[attr-defined]
+    flat_param_shape = flat_param._unsharded_size  # type: ignore[attr-defined]
     assert flat_tensor.shape == flat_param_shape, \
         f"tensor optim state: {flat_tensor.shape} " \
         f"flattened parameter: {flat_param_shape}"

--- a/torch/distributed/fsdp/_optim_utils.py
+++ b/torch/distributed/fsdp/_optim_utils.py
@@ -8,6 +8,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Sequence,
     Tuple,
     Union,
 )
@@ -16,7 +17,10 @@ import torch
 import torch.distributed as dist
 # Import the entire FSDP file to avoid circular imports
 import torch.distributed.fsdp.fully_sharded_data_parallel as FSDP
-from torch.distributed.fsdp.flatten_params_wrapper import FlatParameter
+from torch.distributed.fsdp.flat_param import (
+    FlatParameter,
+    FlatParamHandle,
+)
 
 
 class _ConsolidatedOptimState:
@@ -146,7 +150,7 @@ def _communicate_optim_state(
             # If the parameter is not sharded (e.g. world size of 1), then
             # neither is the positive-dimension tensor state, so no need to
             # communicate it -- we take the target rank's value
-            if not flat_param._is_sharded:
+            if not flat_param._is_sharded:  # type: ignore[attr-defined]
                 tensor_state[state_name] = value.cpu()
                 continue
             if tensor_buffer is None:
@@ -192,7 +196,7 @@ def _unflatten_communicated_optim_state(
     """
     unflat_param_state: List[Dict[str, Any]] = []
     flat_param_views: Dict[str, Iterator] = {}
-    num_unflat_params = flat_param._num_unflattened_params
+    num_unflat_params = flat_param._num_params
     tensor_state, zero_dim_tensor_state, non_tensor_state = \
         state.tensor_state, state.zero_dim_tensor_state, state.non_tensor_state
 
@@ -202,11 +206,11 @@ def _unflatten_communicated_optim_state(
         for state_name, flat_tensor in tensor_state.items():
             views_generated = state_name in flat_param_views
             if not views_generated:
-                param_views = flat_param.get_param_views(flat_tensor)
-                flat_param_views[state_name] = param_views
+                views = FlatParamHandle._get_unflat_views(flat_param, flat_tensor)
+                flat_param_views[state_name] = views
             else:
-                param_views = flat_param_views[state_name]
-            unflat_state_param[state_name] = next(param_views)
+                views = flat_param_views[state_name]
+            unflat_state_param[state_name] = next(views)
         # Add zero-dimension tensor state: take the target rank's value
         for state_name, zero_dim_tensor in zero_dim_tensor_state.items():
             unflat_state_param[state_name] = zero_dim_tensor
@@ -306,7 +310,7 @@ def _flatten_optim_state(
     assert num_unflat_params > 0, \
         "Expects at least one unflattened parameter corresponding to the " \
         "flattened parameter"
-    unflat_param_shapes = flat_param._param_shapes
+    unflat_param_shapes = flat_param._shapes
     num_unflat_param_shapes = len(unflat_param_shapes)
     assert num_unflat_params == num_unflat_param_shapes, \
         f"Expects {num_unflat_params} shapes but got {num_unflat_param_shapes}"
@@ -394,7 +398,7 @@ def _flatten_tensor_optim_state(
     state_name: str,
     pos_dim_tensors: List[torch.Tensor],
     unflat_param_names: List[str],
-    unflat_param_shapes: List[torch.Size],
+    unflat_param_shapes: Sequence[torch.Size],
     flat_param: FlatParameter,
 ) -> torch.Tensor:
     """

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -1,0 +1,468 @@
+import contextlib
+from itertools import accumulate
+from typing import (
+    Dict,
+    Generator,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+__all__ = [
+    "FlatParameter", "FlatParamHandle", "FlatParamShardMetadata",
+    "ParamInfo", "SharedParamInfo",
+]
+
+
+class ParamInfo(NamedTuple):
+    """Information for an original module parameter."""
+    param_name: str  # unprefixed
+    module: nn.Module
+    module_name: str
+
+
+class SharedParamInfo(NamedTuple):
+    """
+    Additional information for a shared parameter.
+
+    For each shared parameter, we designate one module and its parameter
+    variable to be the primary owner, determined as the first one encountered
+    in the parameter walk. These are prefixed with "prim". The primary module
+    and parameter do not have their own :class:`SharedParamInfo` instance.
+    """
+    param_name: str  # unprefixed
+    module: nn.Module
+    module_name: str
+    prim_param_name: str  # unprefixed
+    prim_module: nn.Module
+    prim_module_name: str
+
+
+class FlatParamShardMetadata(NamedTuple):
+    """
+    This holds metadata specific to this rank's shard of the flattened
+    parameter.
+
+    Attributes:
+        param_names (Tuple[str, ...]): Prefixed parameter names of this rank's
+            shard of the parameters; see :class:`FlatParameter`.
+        param_shapes (Tuple[torch.Size, ...]): Parameter shapes of this rank's
+            shard of the parameters; see :class:`FlatParameter`.
+        param_numels (Tuple[int, ...]): Parameter numels of this rank's shard
+            of the parameters; see :class:`FlatParameter`.
+        param_offsets (Tuple[Tuple[int, int], ...]): [start, end] offsets (in
+            units of numels) giving this rank's part of each flattened
+            original module parameter.
+    """
+    param_names: Tuple[str, ...]
+    param_shapes: Tuple[torch.Size, ...]
+    param_numels: Tuple[int, ...]
+    param_offsets: Tuple[Tuple[int, int], ...]
+
+
+class FlatParameter(nn.Parameter):
+    """
+    This is the flattened parameter used by :class:`FullyShardedDataParallel`.
+    It is comprised of one or more original parameters, which are flattened
+    and concatenated to construct the flattened parameter.
+
+    Under the current design, this parameter logically represents both the
+    unsharded and sharded flattened parameter, and its data changes storages
+    dynamically.
+        - In the :class:`FullyShardedDataParallel` constructor, the parameter
+        is initialized as unsharded and then sharded in-place.
+        - At runtime, the parameter is lazily (re)-initialized. The sharded
+        parameter data is saved in ``self._local_shard``, and a new ``Tensor``
+        ``self._full_param_padded`` is created, which is the all-gather
+        destination and owns the unsharded parameter storage thereafter. (See
+        :meth:`FullyShardedDataParallel._init_param_attributes`.)
+        - Throughout runtime, the parameter data changes storages as needed,
+        e.g. to the sharded flattened parameter, reduced-precision sharded
+        flattened parameter, or the unsharded flattened parameter.
+
+    Attributes:
+        _is_sharded (bool): Whether the flattened parameter is *ever* sharded
+            across ranks (not whether it is *currently* sharded).
+        _unsharded_size (torch.Size): Unsharded flattened parameter's size.
+
+        _param_infos (Tuple[ParamInfo, ...]): Each parameter's parameter info
+            entry; see :class:`ParamInfo`.
+        _numels (Tuple[int, ...]): Each parameter's numel.
+        _shapes (Tuple[torch.Size, ...]): Each parameter's shape.
+        _prefixed_param_names (Tuple[str, ...]): Each parameter's name prefixed
+            with the parent module names starting from the module passed to
+            construct this flattened parameter via :class:`FlatParamHandle`;
+            the prefixed names are guaranteed to be unique within the subtree
+            rooted in that module.
+        _num_params (int): Number of original parameters flattened into this
+            flattened parameter; this is the length of ``_param_infos``,
+            ``_numels``, ``_shapes``, and ``_prefixed_param_names``.
+        _shared_param_infos (Tuple[SharedParamInfo, ...]): Shared parameter
+            info entries; see :class:`SharedParamInfo`.
+
+        _shard_param_offsets (List[Tuple[int, int])): [start, end] offsets (in
+            units of numel) giving this rank's part of each flattened original
+            module parameter; for any parameter ``p`` that is not sharded
+            across ranks, this will be [0, ``p.numel()``-1].
+        _shard_indices (Tuple[int, int]): [start, end] indices (in units of
+            parameters) for this rank's shard of the original model parameters,
+            where the parameters follow the order in which they were originally
+            flattened; this indexes appropriately into any data structure that
+            follows the flattening order (e.g. ``_param_infos``, ``_numels``,
+            etc.).
+        _shard_numel_padded (int): Numel padded for this rank's sharded
+            flattened parameter.
+
+        _local_shard (Tensor): Sharded flattened parameter with padding.
+        _full_param_padded (Tensor): Unsharded flattened parameter with
+            padding.
+        _shard_bwd_hook (Tuple[AccumulateGrad, RemovableHandle]): Flattened
+            parameter's :class:`AccumulateGrad` object and post-backward hook
+            handle.
+        _mp_shard (Tensor): Reduced-precision flattened parameter with padding.
+        _cpu_grad (Tensor): Sharded gradient with padding stored on CPU.
+        _saved_grad_shard (Tensor): Sharded gradient with padding from previous
+            iterations for gradient accumulation without :meth:`no_sync`.
+    """
+
+    def init_metadata(
+        self,
+        param_infos: List[ParamInfo],
+        numels: List[int],
+        shapes: List[torch.Size],
+        prefixed_param_names: List[str],
+        shared_param_infos: List[SharedParamInfo],
+    ) -> None:
+        """
+        Initializes attributes holding metadata about the original parameters
+        comprising the flattened parameter.
+
+        We expose this method separate from the constructor to keep the
+        constructor only responsible for the flattened parameter's tensor data.
+        This method should only be called once per model, while the constructor
+        may be called multiple times, e.g. when reloading from a checkpoint, in
+        which case only the tensor data needs to be passed to the constructor.
+        Since :meth:`load_state_dict` is implemented via :meth:`copy_`, the
+        metadata is correctly assumed to be unchanged.
+
+        Args:
+            See the Attributes in the class docstring.
+        """
+        assert len(param_infos) == len(numels)
+        assert len(param_infos) == len(shapes)
+        assert len(param_infos) == len(prefixed_param_names)
+        self._num_params = len(param_infos)
+        self._param_infos = tuple(param_infos)
+        self._numels = tuple(numels)
+        self._shapes = tuple(shapes)
+        self._prefixed_param_names = tuple(prefixed_param_names)
+        self._shared_param_infos = tuple(shared_param_infos)
+        self._is_sharded = False
+        self._unsharded_size = self.size()
+
+
+class FlatParamHandle:
+    """
+    This handle manages a flattened parameter (:class:`FlatParameter`).
+
+    Args:
+        params (Sequence[nn.Parameter]): The parameters to use for the
+            flattened parameter.
+        module (nn.Module): A module that is the root of the subtree containing
+            all parameters in ``params``; for non-recursive wrapping, this must
+            be the top-level module, while for recursive wrapping, this may not
+            necessarily be the top-level module.
+    """
+    def __init__(
+        self,
+        params: Sequence[nn.Parameter],
+        module: nn.Module,
+    ) -> None:
+        super().__init__()
+        self._init_flat_param(module, params)
+        self._unflatten(as_params=False)
+
+    def _init_flat_param(
+        self,
+        module: nn.Module,
+        params: Sequence[Optional[nn.Parameter]],
+    ) -> None:
+        """
+        Initializes the flattened parameter ``self.flat_param`` by flattening
+        the parameters in ``params`` into a single :class:`FlatParameter` and
+        saves relevant metadata. Shared parameters are only included in the
+        flattened parameter once.
+
+        This checks that all comprising parameters have the same dtype and
+        ``requires_grad`` and does not support nested construction of
+        :class:`FlatParameter` s.
+
+        Args:
+            See the Args in the class docstring.
+        """
+        params_set = set(params)
+        params_set.discard(None)
+        assert len(params_set) > 0, \
+            "Cannot initialize a `FlatParameter` from an empty parameter list"
+        param_infos: List[ParamInfo] = []
+        numels: List[int] = []
+        shapes: List[torch.Size] = []
+        prefixed_param_names: List[str] = []
+        shared_param_infos: List[SharedParamInfo] = []
+        shared_param_memo: Dict[nn.Parameter, Tuple[nn.Module, str, str]] = {}
+        params_to_flatten: List[nn.Parameter] = []
+        dtype: Optional[torch.dtype] = None
+        requires_grad: Optional[bool] = None
+        for submodule_name, submodule in module.named_modules():
+            for param_name, param in submodule.named_parameters(recurse=False):
+                if param not in params_set:
+                    continue
+                if param in shared_param_memo:
+                    prim_module, prim_module_name, prim_param_name = shared_param_memo[param]
+                    shared_param_infos.append(SharedParamInfo(
+                        param_name, submodule, submodule_name, prim_param_name,
+                        prim_module, prim_module_name,
+                    ))
+                else:
+                    if isinstance(param, FlatParameter):
+                        raise ValueError("`FlatParameter` does not support nesting")
+                    if dtype is not None and param.dtype != dtype:
+                        raise ValueError(
+                            "`FlatParameter` requires uniform dtype but got "
+                            f"{dtype} and {param.dtype}"
+                        )
+                    if requires_grad is not None and param.requires_grad != requires_grad:
+                        raise ValueError("`FlatParameter` requires uniform `requires_grad`")
+                    dtype = param.dtype
+                    requires_grad = param.requires_grad
+                    shared_param_memo[param] = (submodule, submodule_name, param_name)
+                    params_to_flatten.append(param)
+                    param_infos.append(ParamInfo(param_name, submodule, submodule_name))
+                    numels.append(param.numel())
+                    shapes.append(param.shape)
+                    prefixed_param_name = submodule_name + "." + param_name \
+                        if submodule_name else param_name
+                    prefixed_param_names.append(prefixed_param_name)
+        assert requires_grad is not None
+        self.flat_param = FlatParamHandle.flatten_params(params_to_flatten, requires_grad)
+        self.flat_param.init_metadata(
+            param_infos, numels, shapes, prefixed_param_names, shared_param_infos,
+        )
+
+    @staticmethod
+    def flatten_params(
+        params: Sequence[torch.Tensor],
+        requires_grad: bool,
+    ) -> FlatParameter:
+        """
+        Flattens the parameters in ``params`` into a single
+        :class:`FlatParameter`. This should be the only way used to construct
+        :class:`FlatParameter` s.
+
+        We expose this factory method for checkpointing (e.g. sharded state
+        dict). The flattened parameter's metadata should only be initialized
+        once (see :meth:`init_metadata`), but its tensor data may be reloaded.
+        """
+        with torch.no_grad():
+            flat_params = [
+                p.detach().reshape(-1) if isinstance(p, nn.Parameter)
+                else p.reshape(-1) for p in params
+            ]
+            flat_param_data = torch.cat(flat_params, dim=0)
+        flat_param = FlatParameter(flat_param_data, requires_grad=requires_grad)
+        return flat_param
+
+    @staticmethod
+    def _get_unflat_views(
+        flat_param: FlatParameter,
+        tensor: Optional[torch.Tensor] = None,
+    ) -> Iterator[Tensor]:
+        """
+        Returns unflattened ``Tensor`` views into ``tensor`` if it is not
+        ``None`` or ``flat_param`` otherwise, where the unflattening is based
+        on ``flat_param`` 's metadata.
+
+        In other words, to get views into the unsharded flattened parameter,
+        pass ``tensor`` as ``None``, but to get views into tensor optimizer
+        state, pass ``tensor`` as the optimizer state tensor.
+        """
+        if tensor is None:
+            tensor = flat_param
+        assert tensor.numel() == flat_param._unsharded_size.numel(), \
+            f"Expects {flat_param._unsharded_size.numel()} numel but got " \
+            f"{tensor.numel()} numel"
+        views = (
+            tensor.view(shape) for (tensor, shape) in
+            zip(torch.split(tensor, flat_param._numels, dim=0), flat_param._shapes)  # type: ignore[arg-type]
+        )
+        return views
+
+    def _unflatten(self, as_params: bool) -> None:
+        """
+        Unflattens the unsharded flattened parameter by setting the original
+        module parameter variables to be views into it.
+
+        Args:
+            as_params (bool): If ``True``, then registers the original
+                parameters as ``nn.Parameter`` s; if ``False``, then registers
+                the original parameters only as ``Tensor`` s. ``False`` should
+                be used during forward/backward computation and when hiding the
+                original parameters from :meth:`nn.Module.named_parameters`.
+        """
+        views = self._get_unflat_views(self.flat_param)
+        for view, (param_name, module, _) in zip(views, self.flat_param._param_infos):
+            if hasattr(module, param_name):
+                delattr(module, param_name)
+            if as_params:
+                module.register_parameter(param_name, nn.Parameter(view))
+            else:
+                setattr(module, param_name, view)
+        for (param_name, module, _, prim_param_name, prim_module, _) in self.flat_param._shared_param_infos:
+            if hasattr(module, param_name):
+                delattr(module, param_name)
+            assert hasattr(prim_module, prim_param_name)
+            param: Union[Tensor, nn.Parameter] = getattr(prim_module, prim_param_name)
+            if as_params:
+                assert isinstance(param, nn.Parameter)
+                module.register_parameter(param_name, param)
+            else:
+                setattr(module, param_name, param)
+
+    @contextlib.contextmanager
+    def unflatten_as_params(self) -> Generator:
+        """
+        Assumes the flattened parameter is unsharded. When in the context,
+        unflattens the original parameters as ``nn.Parameter`` views into the
+        flattened parameter, and after the context, restores the original
+        parameters as ``Tensor`` views into the flattened parameter.
+        """
+        self._unflatten(as_params=True)
+        try:
+            yield
+        finally:
+            self._unflatten(as_params=False)
+
+    def init_shard_metadata(
+        self,
+        sharded_flat_param_numel: int,
+        numel_padded: int,
+        rank: int,
+    ) -> None:
+        """
+        Initializes shard-related metadata for this rank's shard of the
+        flattened parameter: ``_shard_param_offsets``, ``_shard_indices``, and
+        ``_shard_numel_padded``.
+
+        Args:
+            sharded_flat_param_numel (int): Numel of each rank's sharded
+                flattened parameter with padding (i.e. including
+                ``numel_padded``).
+            numel_padded (int): Numel padded for this rank's sharded flattened
+                parameter.
+            rank (int): Caller's rank.
+        """
+        if numel_padded > sharded_flat_param_numel:
+            raise ValueError(
+                f"Sharded flattened parameter with {sharded_flat_param_numel} "
+                f"numel cannot have {numel_padded} numel padded"
+            )
+        start = sharded_flat_param_numel * rank
+        end = sharded_flat_param_numel * (rank + 1) - 1  # inclusive
+        self.flat_param._shard_param_offsets, self.flat_param._shard_indices = (  # type: ignore[attr-defined]
+            self._get_shard_metadata(start, end)
+        )
+        self.flat_param._shard_numel_padded = numel_padded  # type: ignore[attr-defined]
+
+    def _get_shard_metadata(
+        self,
+        start: int,
+        end: int,
+    ) -> Tuple[Tuple[Tuple[int, int], ...], Tuple[int, int]]:
+        """
+        Computes the shard metadata based on ``start`` and ``end``, which give
+        the closed interval of the unsharded flattened parameter specifying the
+        shard.
+
+        Args:
+            start (int): Start index (in units of numel) of this rank's shard
+                of the flattened parameter.
+            end (int): End index (in units of numel and inclusive) of this
+                rank's shard of the flattened parameter.
+
+        Return:
+            Tuple[Tuple[Tuple[int, int], ...], Tuple[int, int]]: See
+            ``_shard_param_offsets`` and ``_shard_indices`` in
+            :class:`FlatParameter` 's docstring.
+        """
+        flat_param_offsets = self._get_flat_param_offsets()
+        # Indices of the original parameters in this rank's sharded flattened
+        # parameter
+        shard_param_indices_range = []  # elements will be consecutive
+        # [start, end] offsets giving this rank's part of the flattened
+        # original module parameter (which will be [0, `p.numel()`-1] for any
+        # parameter that is not sharded across ranks)
+        shard_param_offsets = []
+        for i, (param_start, param_end) in enumerate(flat_param_offsets):
+            if start > param_end or end < param_start:
+                continue
+            if start <= param_start:
+                intra_param_start = 0
+            else:
+                intra_param_start = start - param_start
+            intra_param_end = min(param_end, end) - param_start
+            shard_param_indices_range.append(i)
+            shard_param_offsets.append((intra_param_start, intra_param_end))  # both inclusive
+        if len(shard_param_indices_range) == 0:
+            shard_param_indices = (0, 0)
+            assert len(shard_param_offsets) == 0
+        else:
+            shard_param_indices = (
+                shard_param_indices_range[0], shard_param_indices_range[-1],
+            )
+            assert len(shard_param_offsets) == \
+                shard_param_indices[-1] - shard_param_indices[0] + 1
+        return tuple(shard_param_offsets), shard_param_indices
+
+    def _get_flat_param_offsets(self) -> List[Tuple[int, int]]:
+        """Returns [start, end] offsets of each original parameter's flattened
+        data in the unsharded flattened parameter (without padding)."""
+        cumulative_sum = list(accumulate(self.flat_param._numels))
+        starts = [0] + cumulative_sum[:-1]
+        ends = [end - 1 for end in cumulative_sum]  # inclusive
+        param_offsets = list(zip(starts, ends))
+        return param_offsets
+
+    def shard_metadata(
+        self,
+    ) -> FlatParamShardMetadata:
+        """Returns shard-related metadata specific to this rank's shard of the
+        flattened parameter."""
+        assert hasattr(self.flat_param, "_shard_indices") and \
+            hasattr(self.flat_param, "_shard_param_offsets"), \
+            "Shard metadata has not been initialized"
+        shard_param_start_index = self.flat_param._shard_indices[0]  # type: ignore[attr-defined]
+        shard_param_end_index = self.flat_param._shard_indices[1]  # type: ignore[attr-defined]
+        sl = slice(shard_param_start_index, shard_param_end_index + 1) \
+            if shard_param_start_index <= shard_param_end_index else slice(0, 0)
+        return FlatParamShardMetadata(
+            self.flat_param._prefixed_param_names[sl],
+            self.flat_param._shapes[sl],
+            self.flat_param._numels[sl],
+            self.flat_param._shard_param_offsets[:],  # type: ignore[attr-defined]
+        )
+
+    def _get_modules(self) -> Set[nn.Module]:
+        """Returns a :class:`set` of the modules whose parameters are included
+        in this handle's flattened parameter."""
+        return set(pi.module for pi in self.flat_param._param_infos).union(
+            set(spi.module for spi in self.flat_param._shared_param_infos)
+        )

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -15,6 +15,7 @@ from typing import (
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from torch import Tensor
 
 __all__ = [
@@ -431,6 +432,65 @@ class FlatParamHandle:
             assert len(shard_param_offsets) == \
                 shard_param_indices[-1] - shard_param_indices[0] + 1
         return tuple(shard_param_offsets), shard_param_indices
+
+    @staticmethod
+    def _get_unpadded_shard(
+        tensor: Tensor,
+        rank: int,
+        world_size: int,
+    ) -> Tuple[Tensor, int]:
+        """
+        Returns the shard of ``tensor`` without any padding for the given
+        ``rank`` and ``world_size`` and the numel to pad for that shard.
+
+        If ``tensor`` is already flattened or may be viewed in the flattened
+        shape (which is true in the expected usage), then this method does not
+        allocate any new tensor memory.
+        """
+        chunks = torch.flatten(tensor).chunk(world_size)
+        if len(chunks) < (rank + 1):
+            # This rank gets an empty chunk fully padded with zeros since there
+            # are not enough chunks across ranks
+            chunk = chunks[0].new_empty(0)
+        else:
+            chunk = chunks[rank]
+        numel_to_pad = chunks[0].numel() - chunk.numel()
+        assert numel_to_pad >= 0, "Chunk's size should be at most the first chunk's size"
+        return chunk, numel_to_pad
+
+    @staticmethod
+    def _get_shard(
+        tensor: Tensor,
+        rank: int,
+        world_size: int,
+    ) -> Tuple[Tensor, int]:
+        """
+        Returns the shard of ``tensor`` with padding for the given ``rank`` and
+        ``world_size`` and the numel padded for that shard.
+
+        This method allocates new memory (via :meth:`clone`) since the
+        unsharded ``tensor`` may be deallocated after this method returns.
+        """
+        chunk, numel_to_pad = FlatParamHandle._get_unpadded_shard(tensor, rank, world_size)
+        shard = chunk.clone()
+        if numel_to_pad > 0:
+            shard = F.pad(shard, [0, numel_to_pad])
+        return shard, numel_to_pad
+
+    @staticmethod
+    def _get_sharded_size(tensor: Tensor, rank: int, world_size: int) -> torch.Size:
+        """
+        Returns the shape of ``tensor`` after sharding including padding. This
+        requires ``tensor`` to have 1D shape and ensures that the returned
+        shape is 1D.
+        """
+        assert len(tensor.shape) == 1, f"{tensor.shape}"
+        unpadded_sharded_tensor, numel_to_pad = (
+            FlatParamHandle._get_unpadded_shard(tensor, rank, world_size)
+        )
+        unpadded_sharded_size = unpadded_sharded_tensor.size()
+        assert len(unpadded_sharded_size) == 1, f"{unpadded_sharded_size}"
+        return torch.Size([unpadded_sharded_size[0] + numel_to_pad])
 
     def _get_flat_param_offsets(self) -> List[Tuple[int, int]]:
         """Returns [start, end] offsets of each original parameter's flattened

--- a/torch/distributed/fsdp/flat_param.py
+++ b/torch/distributed/fsdp/flat_param.py
@@ -110,6 +110,9 @@ class FlatParameter(nn.Parameter):
         _shared_param_infos (Tuple[SharedParamInfo, ...]): Shared parameter
             info entries; see :class:`SharedParamInfo`.
 
+        _sharded_size (torch.Size): Sharded flattened parameter's size with
+            padding (we omit "padded" from the variable name since there is no
+            concept of an unpadded sharded size).
         _shard_param_offsets (List[Tuple[int, int])): [start, end] offsets (in
             units of numel) giving this rank's part of each flattened original
             module parameter; for any parameter ``p`` that is not sharded
@@ -133,15 +136,23 @@ class FlatParameter(nn.Parameter):
         _cpu_grad (Tensor): Sharded gradient with padding stored on CPU.
         _saved_grad_shard (Tensor): Sharded gradient with padding from previous
             iterations for gradient accumulation without :meth:`no_sync`.
+
+        _params (Optional[Tuple[nn.Parameter, ...]]): Original parameter
+            variables if ``use_orig_params=True``; ``None`` otherwise.
+        _shared_params (Optional[Tuple[nn.Parameter, ...]]): Original shared
+            parameter variables if ``use_orig_params=True``; ``None``
+            otherwise.
     """
 
-    def init_metadata(
+    def _init_metadata(
         self,
         param_infos: List[ParamInfo],
         numels: List[int],
         shapes: List[torch.Size],
         prefixed_param_names: List[str],
         shared_param_infos: List[SharedParamInfo],
+        params: Optional[List[nn.Parameter]],
+        shared_params: Optional[List[nn.Parameter]],
     ) -> None:
         """
         Initializes attributes holding metadata about the original parameters
@@ -167,6 +178,19 @@ class FlatParameter(nn.Parameter):
         self._shapes = tuple(shapes)
         self._prefixed_param_names = tuple(prefixed_param_names)
         self._shared_param_infos = tuple(shared_param_infos)
+        assert (params is None) == (shared_params is None)
+        if params is not None:
+            self._params = tuple(params)
+            self._shared_params = tuple(shared_params)
+            # Set `_flattened` on the original parameters to avoid flattening
+            # them into another `FlatParameter` during recursive construction
+            for param in self._params:
+                param._flattened = True
+            for param in self._shared_params:
+                param._flattened = True
+        else:
+            self._params = None
+            self._shared_params = None
         self._is_sharded = False
         self._unsharded_size = self.size()
 
@@ -182,20 +206,28 @@ class FlatParamHandle:
             all parameters in ``params``; for non-recursive wrapping, this must
             be the top-level module, while for recursive wrapping, this may not
             necessarily be the top-level module.
+        use_orig_params (bool): If ``True``, then preserves the original
+            parameter variables and are exposed in ``named_parameters()`` (e.g.
+            for multiple parameter groups). If ``False``, then the parameter
+            variables are reconstructed every iteration, and instead the
+            :class:`FlatParameter` s are exposed in ``named_parameters()``.
     """
     def __init__(
         self,
         params: Sequence[nn.Parameter],
         module: nn.Module,
+        use_orig_params: bool = False,
     ) -> None:
         super().__init__()
-        self._init_flat_param(module, params)
-        self._unflatten(as_params=False)
+        self._use_orig_params = use_orig_params
+        self._init_flat_param(module, params, use_orig_params)
+        self._use_unsharded_views(as_params=False)
 
     def _init_flat_param(
         self,
         module: nn.Module,
         params: Sequence[Optional[nn.Parameter]],
+        use_orig_params: bool,
     ) -> None:
         """
         Initializes the flattened parameter ``self.flat_param`` by flattening
@@ -212,15 +244,16 @@ class FlatParamHandle:
         """
         params_set = set(params)
         params_set.discard(None)
-        assert len(params_set) > 0, \
-            "Cannot initialize a `FlatParameter` from an empty parameter list"
+        if len(params_set) == 0:
+            raise ValueError("Cannot initialize a `FlatParameter` from an empty parameter list")
         param_infos: List[ParamInfo] = []
         numels: List[int] = []
         shapes: List[torch.Size] = []
         prefixed_param_names: List[str] = []
         shared_param_infos: List[SharedParamInfo] = []
         shared_param_memo: Dict[nn.Parameter, Tuple[nn.Module, str, str]] = {}
-        params_to_flatten: List[nn.Parameter] = []
+        params: List[nn.Parameter] = []
+        shared_params: List[nn.Parameter] = []
         dtype: Optional[torch.dtype] = None
         requires_grad: Optional[bool] = None
         for submodule_name, submodule in module.named_modules():
@@ -229,6 +262,7 @@ class FlatParamHandle:
                     continue
                 if param in shared_param_memo:
                     prim_module, prim_module_name, prim_param_name = shared_param_memo[param]
+                    shared_params.append(param)
                     shared_param_infos.append(SharedParamInfo(
                         param_name, submodule, submodule_name, prim_param_name,
                         prim_module, prim_module_name,
@@ -246,7 +280,7 @@ class FlatParamHandle:
                     dtype = param.dtype
                     requires_grad = param.requires_grad
                     shared_param_memo[param] = (submodule, submodule_name, param_name)
-                    params_to_flatten.append(param)
+                    params.append(param)
                     param_infos.append(ParamInfo(param_name, submodule, submodule_name))
                     numels.append(param.numel())
                     shapes.append(param.shape)
@@ -254,9 +288,15 @@ class FlatParamHandle:
                         if submodule_name else param_name
                     prefixed_param_names.append(prefixed_param_name)
         assert requires_grad is not None
-        self.flat_param = FlatParamHandle.flatten_params(params_to_flatten, requires_grad)
-        self.flat_param.init_metadata(
-            param_infos, numels, shapes, prefixed_param_names, shared_param_infos,
+        self.flat_param = FlatParamHandle.flatten_params(params, requires_grad)
+        self.flat_param._init_metadata(
+            param_infos,
+            numels,
+            shapes,
+            prefixed_param_names,
+            shared_param_infos,
+            params if use_orig_params else None,
+            shared_params if use_orig_params else None,
         )
 
     @staticmethod
@@ -271,7 +311,7 @@ class FlatParamHandle:
 
         We expose this factory method for checkpointing (e.g. sharded state
         dict). The flattened parameter's metadata should only be initialized
-        once (see :meth:`init_metadata`), but its tensor data may be reloaded.
+        once (see :meth:`_init_metadata`), but its tensor data may be reloaded.
         """
         with torch.no_grad():
             flat_params = [
@@ -307,7 +347,7 @@ class FlatParamHandle:
         )
         return views
 
-    def _unflatten(self, as_params: bool) -> None:
+    def _use_unsharded_views(self, as_params: bool) -> None:
         """
         Unflattens the unsharded flattened parameter by setting the original
         module parameter variables to be views into it.
@@ -319,24 +359,128 @@ class FlatParamHandle:
                 be used during forward/backward computation and when hiding the
                 original parameters from :meth:`nn.Module.named_parameters`.
         """
+        self._assert_unsharded(self.flat_param)
         views = self._get_unflat_views(self.flat_param)
-        for view, (param_name, module, _) in zip(views, self.flat_param._param_infos):
+        for i, (view, (param_name, module, _)) in enumerate(zip(views, self.flat_param._param_infos)):
             if hasattr(module, param_name):
                 delattr(module, param_name)
-            if as_params:
+            if self._use_orig_params and as_params:
+                param = self.flat_param._params[i]
+                setattr(module, param_name, param)
+                param.data = view
+            elif as_params:
                 module.register_parameter(param_name, nn.Parameter(view))
             else:
                 setattr(module, param_name, view)
-        for (param_name, module, _, prim_param_name, prim_module, _) in self.flat_param._shared_param_infos:
+        for i, (
+            param_name, module, _, prim_param_name, prim_module, prim_module_name,
+        ) in enumerate(self.flat_param._shared_param_infos):
             if hasattr(module, param_name):
                 delattr(module, param_name)
-            assert hasattr(prim_module, prim_param_name)
+            assert hasattr(prim_module, prim_param_name), (
+                f"Module {prim_module_name} is missing parameter {prim_param_name}"
+            )
             param: Union[Tensor, nn.Parameter] = getattr(prim_module, prim_param_name)
-            if as_params:
-                assert isinstance(param, nn.Parameter)
+            assert not as_params or isinstance(param, nn.Parameter)
+            if self._use_orig_params and as_params:
+                shared_param = self.flat_param._shared_params[i]
+                shared_param.data = param
+            elif as_params:
                 module.register_parameter(param_name, param)
             else:
                 setattr(module, param_name, param)
+
+    @torch.no_grad()
+    def _use_sharded_views(self):
+        """
+        Sets the original module parameter variables' data to be flattened
+        views into the sharded flattened parameter.
+
+        The views are kept as flattened to simplify the case where a parameter
+        is sharded across ranks. Parameters whose data is not present in the
+        sharded flattened parameter are deleted from their modules and have
+        their storages freed while using these sharded views. Parameters whose
+        data is present must preserve their variables to be passable to an
+        optimizer.
+        """
+        assert self._use_orig_params
+        self._assert_sharded(self.flat_param)
+        start, end = self.flat_param._shard_indices
+        offset = 0
+        for i, (param, (param_name, module, _)) in enumerate(
+            zip(self.flat_param._params, self.flat_param._param_infos)
+        ):
+            in_sharded_flat_param = i >= start and i <= end
+            if in_sharded_flat_param:
+                setattr(module, param_name, param)
+                param_start, param_end = self.flat_param._shard_param_offsets[i - start]
+                numel_in_shard = param_end - param_start + 1
+                param.data = self.flat_param[offset:offset + numel_in_shard]
+                offset += numel_in_shard
+            else:
+                if param.storage().size() > 0:
+                    param.storage().resize_(0)
+                if hasattr(module, param_name):
+                    delattr(module, param_name)
+        for i, (param, (param_name, module, _, prim_param_name, prim_module, _)) in enumerate(
+            zip(self.flat_param._shared_params, self.flat_param._shared_param_infos)
+        ):
+            in_sharded_flat_param = hasattr(prim_module, prim_param_name)
+            if in_sharded_flat_param:
+                prim_param = getattr(prim_module, prim_param_name)
+                param.data = prim_param
+            else:
+                assert param.storage().size() == 0, f"{param.storage().size()}"
+
+    @torch.no_grad()
+    def _use_sharded_grad_views(self):
+        """
+        Sets the original module parameter variables' gradients to be flattened
+        views into the sharded flattened parameter's gradient. This is a no-op
+        if there is no gradient.
+
+        Parameters whose data is not present in the sharded flattened parameter
+        and parameters with ``requires_grad=False`` have their gradients set to
+        ``None``. Since the gradient variables do not need to be preserved,
+        this method does not manipulate existing ``Tensor`` data directly and
+        creates new ``Tensor`` variables instead.
+        """
+        assert self._use_orig_params
+        self._assert_sharded(self.flat_param)
+        if self.flat_param.grad is None:
+            return
+        self._assert_sharded(self.flat_param.grad)
+        start, end = self.flat_param._shard_indices
+        offset = 0
+        for i, param in enumerate(self.flat_param._params):
+            in_sharded_flat_param = i >= start and i <= end
+            if in_sharded_flat_param:
+                param_start, param_end = self.flat_param._shard_param_offsets[i - start]
+                numel_in_shard = param_end - param_start + 1
+                if param.requires_grad:
+                    param.grad = self.flat_param.grad[offset:offset + numel_in_shard]
+                else:
+                    param.grad = None
+                offset += numel_in_shard
+            else:
+                param.grad = None
+        for i, (param, (_, _, _, prim_param_name, prim_module, _)) in enumerate(
+            zip(self.flat_param._shared_params, self.flat_param._shared_param_infos)
+        ):
+            in_sharded_flat_param = hasattr(prim_module, prim_param_name)
+            if in_sharded_flat_param and param.requires_grad:
+                prim_param = getattr(prim_module, prim_param_name)
+                param.grad = prim_param.grad  # share the same reference
+            else:
+                param.grad = None
+
+    def _deregister_orig_params(self):
+        for (param_name, module, _) in self.flat_param._param_infos:
+            if hasattr(module, param_name):
+                delattr(module, param_name)
+        for (param_name, module, _, _, _, _) in self.flat_param._shared_param_infos:
+            if hasattr(module, param_name):
+                delattr(module, param_name)
 
     @contextlib.contextmanager
     def unflatten_as_params(self) -> Generator:
@@ -346,17 +490,40 @@ class FlatParamHandle:
         flattened parameter, and after the context, restores the original
         parameters as ``Tensor`` views into the flattened parameter.
         """
-        self._unflatten(as_params=True)
+        self._use_unsharded_views(as_params=True)
         try:
             yield
         finally:
-            self._unflatten(as_params=False)
+            self._use_unsharded_views(as_params=False)
 
-    def init_shard_metadata(
+    def init_shard(self, rank: int, world_size: int) -> None:
+        """
+        Initializes the sharded flattened parameter, constructing the sharded
+        flattened parameter, setting ``flat_param`` 's storage to it, and
+        initializing shard metadata. If the flattened parameter is not sharded,
+        then the "sharded flattened parameter" is simply the flattened
+        parameter itself.
+        """
+        if self.flat_param._is_sharded:
+            sharded_flat_param, numel_padded = (
+                FlatParamHandle._get_shard(self.flat_param, rank, world_size)
+            )
+            self.flat_param.set_(sharded_flat_param)
+            start = sharded_flat_param.numel() * rank
+            end = sharded_flat_param.numel() * (rank + 1) - 1  # inclusive
+            self._init_shard_metadata(sharded_flat_param, numel_padded, start, end)
+        else:
+            self._init_shard_metadata(self.flat_param, 0, 0, self.flat_param.numel() - 1)
+        if self._use_orig_params:
+            self._use_sharded_views()
+            self._use_sharded_grad_views()
+
+    def _init_shard_metadata(
         self,
-        sharded_flat_param_numel: int,
+        sharded_flat_param: Tensor,
         numel_padded: int,
-        rank: int,
+        start: int,
+        end: int,
     ) -> None:
         """
         Initializes shard-related metadata for this rank's shard of the
@@ -364,20 +531,21 @@ class FlatParamHandle:
         ``_shard_numel_padded``.
 
         Args:
-            sharded_flat_param_numel (int): Numel of each rank's sharded
-                flattened parameter with padding (i.e. including
-                ``numel_padded``).
+            sharded_flat_param (Tensor): Sharded flattened parameter.
             numel_padded (int): Numel padded for this rank's sharded flattened
                 parameter.
-            rank (int): Caller's rank.
+            start (int): Start index in the sharded flattened parameter
+                assigned to this rank.
+            end (int): End index (inclusive) in the sharded flattened parameter
+                assigned to this rank. If this exceeds the sharded flattened
+                parameter's numel, then it is truncated.
         """
-        if numel_padded > sharded_flat_param_numel:
-            raise ValueError(
-                f"Sharded flattened parameter with {sharded_flat_param_numel} "
-                f"numel cannot have {numel_padded} numel padded"
-            )
-        start = sharded_flat_param_numel * rank
-        end = sharded_flat_param_numel * (rank + 1) - 1  # inclusive
+        self.flat_param._sharded_size = sharded_flat_param.size()
+        sharded_flat_param_numel = sharded_flat_param.numel()  # includes `numel_padded`
+        assert start >= 0 and start <= end, f"start: {start} end: {end}"
+        assert numel_padded <= sharded_flat_param_numel, (
+            f"numel_padded: {numel_padded} sharded_flat_param_numel: {sharded_flat_param_numel}"
+        )
         self.flat_param._shard_param_offsets, self.flat_param._shard_indices = (  # type: ignore[attr-defined]
             self._get_shard_metadata(start, end)
         )
@@ -526,3 +694,25 @@ class FlatParamHandle:
         return set(pi.module for pi in self.flat_param._param_infos).union(
             set(spi.module for spi in self.flat_param._shared_param_infos)
         )
+
+    def _assert_unsharded(self, tensor: Tensor) -> None:
+        """Asserts that ``tensor`` is unsharded, i.e. that it has the same
+        shape as the unsharded flattened parameter."""
+        assert tensor is not None
+        assert tensor.size() == self.flat_param._unsharded_size, (
+            f"Expects {self.flat_param._unsharded_size} but got {tensor.size()}"
+        )
+
+    def _assert_sharded(self, tensor: Tensor) -> None:
+        """Asserts that ``tensor`` is sharded, i.e. that it has the same shape
+        as the sharded flattened parameter."""
+        assert tensor is not None
+        assert tensor.size() == self.flat_param._sharded_size, (
+            f"Expects {self.flat_param._sharded_size} but got {tensor.size()}"
+        )
+
+
+def same_storage(x, y):
+	x_ptrs = set(e.data_ptr() for e in x.view(-1))
+	y_ptrs = set(e.data_ptr() for e in y.view(-1))
+	return (x_ptrs <= y_ptrs) or (y_ptrs <= x_ptrs)

--- a/torch/distributed/fsdp/flatten_params_wrapper.py
+++ b/torch/distributed/fsdp/flatten_params_wrapper.py
@@ -7,30 +7,17 @@
 # Licensed under the MIT License.
 
 import contextlib
-from itertools import accumulate
-from typing import (
-    Any,
-    Dict,
-    Generator,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Tuple,
-)
+from typing import Any, Dict, Generator, List
 
-import torch
 import torch.nn as nn
-from torch import Tensor
-
 from torch.distributed.utils import _replace_by_prefix
 
+from .flat_param import FlatParamHandle
 
-ParamOffset = Tuple[int, int]
-SharedParamInfo = Tuple[str, str, nn.Module, str, nn.Module, str]
 FLAT_PARAM = "flat_param"
 FPW_MODULE = "_fpw_module"
+
+__all__ = ["FlattenParamsWrapper"]
 
 
 def _post_state_dict_hook(
@@ -70,407 +57,100 @@ def _pre_load_state_dict_hook(
             _replace_by_prefix(state_dict, k, prefix + last_part)
 
 
-class ParamInfo(NamedTuple):
-    module_name: str
-    module: nn.Module
-    param_name: str
-
-
-class ShardMetadata(NamedTuple):
-    param_names: List[str]
-    param_shapes: List[torch.Size]
-    param_numels: List[int]
-    param_offsets: List[ParamOffset]
-
-
-class FlatParameter(nn.Parameter):
-    """
-    A parameter that is initialized from a list of parameters. All the
-    parameters will be flattened and concatened to form the flat parameter.
-
-    Args:
-        params (Sequence[nn.Parameter])
-            The parameters to be flattend and concatened.
-        requires_grad (bool):
-            Set to True if gradients need to be computed for this parameter,
-            False otherwise.
-    """
-
-    def __new__(
-        cls, params: Sequence[nn.Parameter], requires_grad: bool = True
-    ) -> "FlatParameter":
-        """Make an object using the parent's __new__ function."""
-
-        # A empty or non-list input doesn't make sense.
-        if not isinstance(params, (list, tuple)) or len(params) == 0:
-            raise ValueError("An non-empty list or tuple argument is needed")
-
-        # Normally, all items are Parameters. But during pickling, we will have a single
-        # Tensor as the input and later in __init__, the correct _param_numels and _param_shapes
-        # are set.
-        if not all(isinstance(p, (nn.Parameter, Tensor)) for p in params):
-            incorrect_parameters = [
-                p for p in params if not isinstance(p, (nn.Parameter, Tensor))
-            ]
-            raise ValueError(
-                f"List items need to be Parameter types {incorrect_parameters}"
-            )
-
-        # Flattening involves (1) making a tensor flat (i.e. single dimensional) and
-        # (2) making a module hierarchy flat (using a single tensor to replace a tree of
-        # tensors). Therefore, adding back nesting and hierarchy is counter-productive.
-        # If nesting is encountered in the future, the reasonable thing to do is likely
-        # for the top level FlatParameter to absorb the nested one and keep the result flat,
-        # free from hierarchy.
-        if any(isinstance(p, FlatParameter) for p in params):
-            raise ValueError("Nesting FlatParameter is not supported")
-
-        data = torch.cat(
-            [
-                p.detach().reshape(-1) if isinstance(p, nn.Parameter) else p.reshape(-1)
-                for p in params
-            ],
-            0,
-        )
-
-        return super(FlatParameter, cls).__new__(
-            cls, data, requires_grad=requires_grad
-        )  # type: ignore[call-arg]
-
-    def __init__(self, params: Sequence[nn.Parameter], requires_grad: bool = True):
-        self._is_sharded = False
-        self._param_numels = [p.numel() for p in params]
-        # The total element numbers. This is equal to the summation of the
-        # ``numel()`` of all the parameters.
-        self.full_numel = sum(self._param_numels)
-        assert self.numel() <= self.full_numel, (
-            "Parameter numbers mismatched. "
-            f"The number of elements in FlatParameter: {self.numel()} vs. "
-            f"the number of elements in original parameters: {self.full_numel}."
-        )
-        # The shapes of each individual parameter.
-        self._param_shapes = [p.size() for p in params]
-        cumulative_sum = list(accumulate(self._param_numels))
-        begin = [0] + cumulative_sum[:-1]
-        end = [e - 1 for e in cumulative_sum]
-
-        self._param_infos: List[ParamInfo] = []
-        self._shared_param_infos: List[SharedParamInfo] = []
-
-        # The element offsets (begin/end pair) in the flat parameter of each
-        # individual parameter.
-        self._param_offsets = list(zip(begin, end))
-        # The indices (begin/end pair) of the parameters that are included in
-        # this FlatParameter. The default value is all the parameters because
-        # no sharding happen yet.
-        self._param_indice_in_shard = (0, len(self._param_infos) - 1)
-        # The offsets in each parameter that is included in the FlatParameter.
-        self._sharded_param_offsets: List[ParamOffset] = [
-            (0, numel) for numel in self._param_numels
-        ]
-        # The number of padding elements.
-        self.num_padded = 0
-
-    def shard_by_offsets(self, start: int, end: int, num_padded: int) -> None:
-        assert self._is_sharded
-        if start < 0 or end < 0 or end < start:
-            raise ValueError(
-                f"Shard the flatten parameter with an invalid offset pair {(start, end)}."
-            )
-        _shard_size = end - start + 1
-        self.num_padded = num_padded
-        if self.num_padded > _shard_size:
-            raise ValueError("The number of padding is larger than the shard size.")
-        self._sharded_param_offsets.clear()
-
-        ranges = []
-        for idx, offset in enumerate(self._param_offsets):
-            if start > offset[1] or end < offset[0]:
-                continue
-            if start <= offset[0]:
-                sharded_param_start = 0
-                sharded_param_end = min(offset[1], end) - offset[0]
-            else:
-                sharded_param_start = start - offset[0]
-                sharded_param_end = min(offset[1], end) - offset[0]
-            ranges.append(idx)
-            self._sharded_param_offsets.append((sharded_param_start, sharded_param_end))
-        if ranges:
-            self._param_indice_in_shard = (ranges[0], ranges[-1])
-
-    def _offset_to_slice(self) -> slice:
-        if self._param_indice_in_shard[0] > self._param_indice_in_shard[1]:
-            return slice(0, 0)
-        return slice(self._param_indice_in_shard[0], self._param_indice_in_shard[1] + 1)
-
-    def get_param_views(
-        self, external_data: Optional[Tensor] = None
-    ) -> Iterator[Tensor]:
-        """Return a generator of views that map to the original parameters."""
-        # Note, self.data could be sharded, so its numel is <= to the sum.
-        assert (
-            self.data.numel() <= self.full_numel
-        ), f"Incorrect internal state {self.data.numel()} vs. {self.full_numel}"
-        data = external_data if external_data is not None else self
-        if data.numel() != self.full_numel:
-            raise ValueError(
-                f"Incorrect numel of supplied data: got {data.numel()} but expected {self.full_numel}"
-            )
-        return (
-            t.view(s)
-            for (t, s) in zip(data.split(self._param_numels), self._param_shapes)
-        )
-
-    @property
-    def _num_unflattened_params(self) -> int:
-        """Returns the number of unflattened parameters that comprise this
-        flattened parameter."""
-        assert hasattr(self, "_param_infos"), \
-            "`_param_infos` has not been set, meaning this `FlatParameter` " \
-            "has not been initialized yet"
-        num_unflat_params = len(self._param_infos)
-        assert num_unflat_params > 0, "`FlatParameter` corresponding to 0 " \
-            "unflattened parameters"
-        return num_unflat_params
-
-    @property
-    def param_info(self) -> List[ParamInfo]:
-        return self._param_infos
-
-    @property
-    def _param_names(self):
-        return [".".join([m, n]) if m else n for (m, _, n) in self._param_infos]
-
-    def metadata(self) -> Tuple[List[str], List[torch.Size], List[int]]:
-        """Return tuple of (names, shapes, numels) metadata for this flat parameter."""
-        return self._param_names, self._param_shapes, self._param_numels
-
-    def shard_metadata(
-        self,
-    ) -> ShardMetadata:
-        """
-        Return tuple of (names, shapes, numels) metadata for the sharded parameter
-        metadata of this flat parameter.
-        """
-        return ShardMetadata(
-            self._param_names[self._offset_to_slice()],
-            self._param_shapes[self._offset_to_slice()],
-            self._param_numels[self._offset_to_slice()],
-            self._sharded_param_offsets[:],
-        )
-
-
 class FlattenParamsWrapper(nn.Module):
     """
-    A wrapper for transparently flattening a Module's parameters.
-    The original implementation [1] reparameterizes a PyTorch module
-    that is called ReparamModule. The ReparamModule has only a flattened
-    parameter representing all parameters of the wrapped module.
-    Compared to the original implementation [1], this version:
-    - removes tracing
-    - supports shared parameters
-    - is renamed to FlattenParamsWrapper
+    This is a wrapper for flattening parameters in a ``nn.Module`` 's subtree
+    into a single flattened parameter and is based on [1]. This is used for
+    :class:`FullyShardedDataParallel` 's recursive wrapping.
     [1] https://github.com/SsnL/PyTorch-Reparam-Module
-    Args:
-        module (nn.Module):
-            The module to wrap.
-        param_list (List[nn.Parameter]):
-            Only flatten parameters appearing in the given list.
-            Note, if only a single param is in the list, it still gets
-            flattened and the original param is removed and replaced
-            with the flatten one.
-    """
 
-    def __init__(self, module: nn.Module, param_list: List[nn.Parameter]):
+    Args:
+        module (nn.Module): Module to wrap.
+        params (List[nn.Parameter]): Parameters in ``module`` 's subtree to
+            flatten into a single flattened parameter.
+
+    Attributes:
+        flat_param (Optional[FlatParameter]): The flattened parameter.
+            ``flat_param`` is ``None`` either when (1) this wrapper manages no
+            parameters or (2) the wrapped module's parameters are unflattened.
+        _fpw_module (nn.Module): The wrapped module.
+        _flat_param_handle (FlatParamHandle): A handle for the flattened
+            parameter; only present if this wrapper manages parameters.
+    """
+    def __init__(
+        self,
+        module: nn.Module,
+        params: List[nn.Parameter],
+    ) -> None:
         super().__init__()
         self._fpw_module = module
-        # People may test whether this module contains parameters by using
-        # `getattr(module, "flat_param") is None`. This is not always accurate
-        # as the above condition is also true if this module is unflattened.
-        # `no_params` explicitly shows this module has no parameters and
-        # is always correct regardless flattened or unflattened.
-        self.no_params = True
         self.flat_param = None
-
-        # Register hook to be called after state_dict() to remove the
-        # "_fpw_module." prefix and before load_state_dict() to add it back.
-        # The hooks must be registered even if the target param_list is empty as
-        # all submodules in FlattenParamsWrapper should be pre/post processed by
-        # the hooks.
+        # Register hooks to clean parameter names for state dict (even if this
+        # wrapper itself manages no parameters since it must clean names from
+        # submodules)
         self._register_state_dict_hook(_post_state_dict_hook)
         self._register_load_state_dict_pre_hook(_pre_load_state_dict_hook)
-
-        if len(param_list) == 0:
+        if len(params) == 0:
             return
-
-        # A list of parameters to be flatten
-        unique_param_list = set(param_list)
-        self.no_params = False
-
-        # convert from list of Parameters to set of (Module, parameter_name) tuples, which
-        # will survive in case the Parameter instances are reset.
-        # it includes (m, n) that points to the same parameter.
-        self.param_set = set()
-        for m in self.modules():
-            for n, p in m.named_parameters(recurse=False):
-                if p in unique_param_list:
-                    self.param_set.add((m, n))
-
-        params, param_infos, shared_param_infos = self._init_flatten_params()
-        self.flat_param = FlatParameter(params, params[0].requires_grad)
-        self.flat_param._param_infos = param_infos
-        self.flat_param._shared_param_infos = shared_param_infos
-
-        # This attribute is used to remember the flat_param inside the unflatten_params()
-        # context. With this attribute, FSDP can access the flat parameter metadata
-        # even if flat_param is temporarily deleted.
-        # ``orig_flat_param` is a list to avoid being tracked by ``state_dict()``.
-        self.orig_flat_param: List[Optional[FlatParameter]] = [None]
-        self._flatten_params()
-
-        # Sanity check for the string constants.
+        self._flat_param_handle = FlatParamHandle(params, module)
+        # Defining `self.flat_param` registers the `FlatParameter` and makes it
+        # visible to `named_parameters()`
+        self.flat_param = self._flat_param_handle.flat_param
         assert getattr(self, FPW_MODULE) is self._fpw_module
         assert getattr(self, FLAT_PARAM) is self.flat_param
 
     @property
+    def has_params(self) -> bool:
+        """Returns whether this wrapper manages any parameters."""
+        return hasattr(self, "_flat_param_handle")
+
+    @property
+    def handle(self) -> FlatParamHandle:
+        assert hasattr(self, "_flat_param_handle"), \
+            "Accessing the handle of a `FlattenParamsWrapper` that does not " \
+            "manage any parameters"
+        return self._flat_param_handle
+
+    @property
     def module(self) -> Any:
-        """Support _fsdp_wrapped_module.module in case we are immitating DDP, which has .module
-        property to the underlying module.
-        """
+        """Returns the wrapped module (like DDP)."""
         return self._fpw_module
 
-    def _init_flatten_params(
-        self,
-    ) -> Tuple[List[nn.Parameter], List[ParamInfo], List[SharedParamInfo]]:
-        """Build metadata for need-to-be-flatten parameters and returns a list
-        contains the need-to-be-flatten parameters.
-        This also fills param_infos and shared_param_infos.
-        """
-        param_infos: List[ParamInfo] = []
-        shared_param_infos = []
-        shared_param_memo: Dict[nn.Parameter, Tuple[str, nn.Module, str]] = {}
-        params = []
-        for module_name, m in self.named_modules():
-            for n, p in m.named_parameters(recurse=False):
-                if p is not None and (m, n) in self.param_set:
-                    if p in shared_param_memo:
-                        mname, shared_m, shared_n = shared_param_memo[p]
-                        shared_param_infos.append(
-                            (module_name, mname, m, n, shared_m, shared_n)
-                        )
-                    else:
-                        shared_param_memo[p] = (module_name, m, n)
-                        param_infos.append(ParamInfo(module_name, m, n))
-                        params.append(p)
-        del shared_param_memo
-
-        assert (
-            len(set(p.dtype for p in params)) == 1
-        ), "expects all parameters to have same dtype"
-        assert (
-            len(set(p.requires_grad for p in params)) == 1
-        ), "expects all parameters to have same requires_grad"
-        assert len(params) == len(set(params)), "params list should not have dups"
-
-        return params, param_infos, shared_param_infos
-
-    def _flatten_params(self, external_data: Optional[FlatParameter] = None) -> None:
-        """Flatten the managed parameters and replaced the original
-        attributes with views to the flat param. If `external_data`
-        is passed, it will be used as the flat_param.
-        """
-        # register the flatten one
-        assert (
-            getattr(self, "flat_param", None) is not None or external_data is not None
-        ), "Can not flatten params when both flat_param and external_data are None."
-        if external_data is not None:
-            self.flat_param = external_data
-        self.register_parameter("flat_param", self.flat_param)
-
-        assert self.flat_param is not None  # avoid mypy complain.
-        # deregister the names as parameters
-        for _, m, n in self.flat_param._param_infos:
-            delattr(m, n)
-        for _, _, m, n, _, _ in self.flat_param._shared_param_infos:
-            delattr(m, n)
-
-        # register the views as plain attributes
-        self._unflatten_params_as_views()
-
-    def _unflatten_params_as_views(self) -> None:
-        """Unlike ``_unflatten_params``, this function unflatten into views and keep
-        self.flat_param unchanged.
-        """
-        assert (
-            self.flat_param is not None
-        ), "Can not unflatten params as views when flat_param is None."
-        ps = self._get_param_views()
-        for (_, m, n), p in zip(self.flat_param._param_infos, ps):
-            setattr(m, n, p)  # This will set as plain attr
-
-        for (_, _, m, n, shared_m, shared_n) in self.flat_param._shared_param_infos:
-            setattr(m, n, getattr(shared_m, shared_n))
-
-    def _unflatten_params(self) -> None:
-        """Undo flattening and create separate parameters from the already flattened
-        self.flat_param.
-        """
-        assert (
-            self.flat_param is not None
-        ), "Can not unflatten params when flat_param is None."
-        ps = self._get_param_views()
-        for (_, m, n), p in zip(self.flat_param._param_infos, ps):
-            if hasattr(m, n):
-                delattr(m, n)
-            m.register_parameter(n, nn.Parameter(p))
-        for (_, _, m, n, shared_m, shared_n) in self.flat_param._shared_param_infos:
-            if hasattr(m, n):
-                delattr(m, n)
-            m.register_parameter(n, getattr(shared_m, shared_n))
-
-        del self.flat_param
-
     @contextlib.contextmanager
-    def unflatten_params(self) -> Generator:
+    def unflatten_as_params(self) -> Generator:
         """
-        Unflatten params. If the current instance is already unflattened, then
-        it will remain unflattened after the context manager exits.
+        Assumes that the flattened parameter is unsharded. When in the context,
+        unflattens the original parameters as ``nn.Parameter`` views into the
+        flattened parameter and de-registers the flattened parameter. After the
+        context, restores the original parameters as ``Tensor`` views into the
+        flattened parameter and re-registers the flattened parameter.
         """
         if getattr(self, "flat_param", None) is None:
             yield
         else:
-            self.orig_flat_param[0] = self.flat_param
-            self._unflatten_params()
-            # Put yield in a try...finally in case the caller catches the exception and handles
-            # it. In that case, we need to properly handle the undoing of state here.
+            # De-register the `FlatParameter` from this wrapper to hide it from
+            # `named_parameters()` (though it still exists in memory)
+            del self.flat_param
             try:
-                yield
+                with self._flat_param_handle.unflatten_as_params():
+                    yield
             finally:
-                self._flatten_params(self.orig_flat_param[0])
-                self.orig_flat_param[0] = None
-
-    def _get_param_views(
-        self, external_data: Optional[Tensor] = None
-    ) -> Iterator[Tensor]:
-        """Return a generator of views that map to the original parameters."""
-        assert self.flat_param is not None
-        return self.flat_param.get_param_views(external_data)
+                # Re-register the `FlatParameter`
+                self.flat_param = self._flat_param_handle.flat_param
 
     def __getattr__(self, name: str) -> Any:
-        """Forward missing attributes to wrapped module."""
+        """Forward missing attributes of this wrapper to the wrapped module."""
         try:
-            return super().__getattr__(name)  # defer to nn.Module's logic
+            return super().__getattr__(name)  # defer to `nn.Module`'s logic
         except AttributeError:
-            return getattr(self.module, name)  # fallback to wrapped module
+            return getattr(self.module, name)  # fall back to the wrapped module
 
     def __getitem__(self, key: int) -> Any:
-        """Forward indexing calls in case the module is a nn.Sequential."""
+        """Forward indexing calls to the wrapped module in case the wrapped
+        module is an ``nn.Sequential``."""
         return self.module.__getitem__(key)
 
-    def _unflatten_params_if_needed(self) -> None:
-        if self.flat_param is not None:
-            self._unflatten_params_as_views()
-
     def forward(self, *inputs: Any, **kwinputs: Any) -> Any:
-        self._unflatten_params_if_needed()
+        if self.flat_param is not None:
+            self._flat_param_handle._unflatten(as_params=False)
         return self.module(*inputs, **kwinputs)

--- a/torch/distributed/fsdp/flatten_params_wrapper.py
+++ b/torch/distributed/fsdp/flatten_params_wrapper.py
@@ -7,12 +7,12 @@
 # Licensed under the MIT License.
 
 import contextlib
-from typing import Any, Dict, Generator, List
+from typing import Any, Dict, Generator, List, Optional
 
 import torch.nn as nn
 from torch.distributed.utils import _replace_by_prefix
 
-from .flat_param import FlatParamHandle
+from .flat_param import FlatParameter, FlatParamHandle
 
 FLAT_PARAM = "flat_param"
 FPW_MODULE = "_fpw_module"
@@ -81,10 +81,10 @@ class FlattenParamsWrapper(nn.Module):
         self,
         module: nn.Module,
         params: List[nn.Parameter],
+        use_orig_params: bool = False,
     ) -> None:
         super().__init__()
         self._fpw_module = module
-        self.flat_param = None
         # Register hooks to clean parameter names for state dict (even if this
         # wrapper itself manages no parameters since it must clean names from
         # submodules)
@@ -92,12 +92,15 @@ class FlattenParamsWrapper(nn.Module):
         self._register_load_state_dict_pre_hook(_pre_load_state_dict_hook)
         if len(params) == 0:
             return
-        self._flat_param_handle = FlatParamHandle(params, module)
-        # Defining `self.flat_param` registers the `FlatParameter` and makes it
-        # visible to `named_parameters()`
-        self.flat_param = self._flat_param_handle.flat_param
+        self._flat_param_handle = FlatParamHandle(params, module, use_orig_params)
+        if not use_orig_params:
+            self._register_flat_param()
         assert getattr(self, FPW_MODULE) is self._fpw_module
         assert getattr(self, FLAT_PARAM) is self.flat_param
+
+    @property
+    def flat_param(self) -> Optional[FlatParameter]:
+        return self.handle.flat_param if self.has_params else None
 
     @property
     def has_params(self) -> bool:
@@ -120,23 +123,44 @@ class FlattenParamsWrapper(nn.Module):
     def unflatten_as_params(self) -> Generator:
         """
         Assumes that the flattened parameter is unsharded. When in the context,
-        unflattens the original parameters as ``nn.Parameter`` views into the
-        flattened parameter and de-registers the flattened parameter. After the
-        context, restores the original parameters as ``Tensor`` views into the
-        flattened parameter and re-registers the flattened parameter.
+        de-registers the flattened parameter and unflattens the original
+        parameters as ``nn.Parameter`` views into the flattened parameter.
+        After the context, re-registers the flattened parameter and restores
+        the original parameters as ``Tensor`` views into the flattened
+        parameter.
         """
-        if getattr(self, "flat_param", None) is None:
+        if self.flat_param is None:
             yield
         else:
-            # De-register the `FlatParameter` from this wrapper to hide it from
-            # `named_parameters()` (though it still exists in memory)
-            del self.flat_param
+            self._deregister_flat_param()
             try:
                 with self._flat_param_handle.unflatten_as_params():
                     yield
             finally:
-                # Re-register the `FlatParameter`
-                self.flat_param = self._flat_param_handle.flat_param
+                if not self.handle._use_orig_params:
+                    self._register_flat_param()
+
+    def _register_flat_param(self):
+        """
+        Registers the flattened parameter, making it visible to ``nn.Module``
+        methods.
+        
+        We do not use :meth:`nn.Module.register_parameter` because we want
+        ``flat_param`` to always be an attribute but dynamically change whether
+        it is visible to ``nn.Module`` methods.
+        """
+        self._parameters["flat_param"] = self.flat_param
+
+    def _deregister_flat_param(self):
+        """
+        De-registers the flattened parameter, hiding it from ``nn.Module``
+        methods.
+        
+        We do not use ``del self.flat_param`` because we want ``flat_param`` to
+        always be an attribute but dynamically change whether it is visible to
+        ``nn.Module`` methods.
+        """
+        self._parameters.pop("flat_param", None)
 
     def __getattr__(self, name: str) -> Any:
         """Forward missing attributes of this wrapper to the wrapped module."""
@@ -152,5 +176,5 @@ class FlattenParamsWrapper(nn.Module):
 
     def forward(self, *inputs: Any, **kwinputs: Any) -> Any:
         if self.flat_param is not None:
-            self._flat_param_handle._unflatten(as_params=False)
+            self._flat_param_handle._use_unsharded_views(as_params=False)
         return self.module(*inputs, **kwinputs)

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -110,9 +110,9 @@ def transformer_auto_wrap_policy(
        unwrapped_params (int):
            The number of parameters yet to be wrapped in this module.
 
-       transformer_layer_cls (int):
+       transformer_layer_cls (Set[Type[nn.Module]]):
            Submodules with one of the `transformer_layer_cls` names
-           will be wrapped as seperated FSDP units
+           will be wrapped as separate FSDP units
     """
     if recurse:
         # always recurse

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -531,13 +531,14 @@ class FSDPTest(MultiProcessTestCase):
         model_init_fn,
         *args,
         ref_ddp_fn=None,
-        num_steps=2,
+        num_steps=1,
         fsdp_init_mode=FSDPInitMode.CUDA_AFTER,
         lr=0.01,
         cpu_offload=CPUOffload(),
         backward_prefetch=None,
         forward_prefetch=False,
         sharding_strategy=None,
+        use_orig_params=False,
         mixed_precision=None,
         save_model=True,
         clip_norm=0.3,
@@ -575,9 +576,10 @@ class FSDPTest(MultiProcessTestCase):
                 forward_prefetch=forward_prefetch,
                 sharding_strategy=sharding_strategy,
                 mixed_precision=mixed_precision,
+                use_orig_params=use_orig_params,
             )
         except Exception as e:
-            raise ValueError(f"model_Init_fn {model_init_fn} got error {str(e)}")
+            raise ValueError(f"model_init_fn {model_init_fn} got error {str(e)}")
 
         cpu_offload = cpu_offload or CPUOffload()  # disabled if not specified.
         model = FullyShardedDataParallel(
@@ -587,6 +589,7 @@ class FSDPTest(MultiProcessTestCase):
             forward_prefetch=forward_prefetch,
             sharding_strategy=sharding_strategy,
             mixed_precision=mixed_precision,
+            use_orig_params=use_orig_params,
         )
         # Call model.cuda() after init FSDP if specified.
         if fsdp_init_mode == FSDPInitMode.CUDA_AFTER:


### PR DESCRIPTION
**To-Do**
- [] Consider implementing the "dynamically parameterized" `FlatParameter` that preserves the original parameter variables by subclassing `FlatParamHandle` with something like `OrigParamFlatParamHandle` (final name is pending).
    - `FlatParameter._init_metadata()` can be moved to `FlatParamHandle`.
    - `OrigParamFlatParamHandle` implements `_use_unsharded_views()`, `_use_sharded_grad_views()` and overrides `_init_flat_param()`, `_use_unsharded_views()`, `_init_metadata()`.
    - I am considering subclassing in the first place because we may have more variants in the future -- for example, for TP + FSDP integration, we may need a `ShardedTensor`-backed `FlatParameter`. For this, we could either modify the existing `FlatParamHandle`, or we could introduce a `ShardedTensorFlatParamHandle` that simply overrides the necessary logic.